### PR TITLE
フロント - ランキングページのh1文面修正

### DIFF
--- a/WebContent/billboard/assets/js/ranking.js
+++ b/WebContent/billboard/assets/js/ranking.js
@@ -23,7 +23,7 @@ const Ranking = () => {
       <Header />
       <div className="page-container">
         <div className="spotify-container">
-          <h1>KINDAI CHART 10</h1>
+          <h1>KINDAI CHART</h1>
           <a
             href="https://open.spotify.com/playlist/1EYHrEKAHQKKLdmF4W5dYl"
             target="_blank"


### PR DESCRIPTION
## issue

- #103 

## なぜやるのか

- ランキング表示数が10でないのに、KINDAI CHART 10 という文面はおかしいため

## なにをやったのか

- h1のテキストを修正